### PR TITLE
Fixing duplicate classes …

### DIFF
--- a/iron-grid.html
+++ b/iron-grid.html
@@ -235,7 +235,7 @@ It is recomended to only apply logging on iron-grid one at a time. If not, you w
         --iron-grid-order-2: 2;
         --iron-grid-order-3: 3;
         --iron-grid-order-4: 4;
-        --iron-grid-order-4: 5;
+        --iron-grid-order-5: 5;
         --iron-grid-order-6: 6;
         --iron-grid-order-7: 7;
         --iron-grid-order-8: 8;
@@ -247,7 +247,7 @@ It is recomended to only apply logging on iron-grid one at a time. If not, you w
         --iron-grid-order-2-important: 2 !important;
         --iron-grid-order-3-important: 3 !important;
         --iron-grid-order-4-important: 4 !important;
-        --iron-grid-order-4-important: 5 !important;
+        --iron-grid-order-5-important: 5 !important;
         --iron-grid-order-6-important: 6 !important;
         --iron-grid-order-7-important: 7 !important;
         --iron-grid-order-8-important: 8 !important;


### PR DESCRIPTION
While we're at it... 

Those 2 classes were duplicated: 
- `iron-grid-order-4` 
- `iron-grid-order-4-important` 

(causing others - the #5s - to be missing)

Thanks WebStorm for putting this in my face! :)
