### PR TITLE
Fixed `--iron-container-width`

### DIFF
--- a/iron-grid.html
+++ b/iron-grid.html
@@ -2554,15 +2554,11 @@ Custom property | Description | Default
 <dom-module id="iron-grid-container">
   <template>
     <style>
-      :host {
-        --iron-container-width: 90%;
-      }
-
       .iron-container {
         padding: 0 1.5 rem;
         margin: 0 auto;
         max-width: 1280px;
-        width: var(--iron-container-width);
+        width: var(--iron-container-width, 90%);
       }
 
       .iron-container::content iron-grid {


### PR DESCRIPTION
`--iron-container-width` had been hardcoded by setting the var in `:host`:

```
:host {
    --iron-container-width: 90%;
}

.iron-container {
    width: var(--iron-container-width);
}
```

Instead, set `var()` to use a fallback parameter:

```
.iron-container {
    width: var(--iron-container-width, 90%);
}
```

See: https://www.polymer-project.org/1.0/docs/devguide/styling#custom-css-properties
