### PR TITLE
remove space between value and unit

### DIFF
--- a/iron-grid.html
+++ b/iron-grid.html
@@ -2555,15 +2555,15 @@ Custom property | Description | Default
   <template>
     <style>
       .iron-container {
-        padding: 0 1.5 rem;
+        padding: 0 1.5rem;
         margin: 0 auto;
         max-width: var(--iron-container-max-width, 1280px);
         width: var(--iron-container-width, 90%);
       }
 
       .iron-container::content iron-grid {
-        margin-left: -0.75 rem;
-        margin-right: -0.75 rem;
+        margin-left: -0.75rem;
+        margin-right: -0.75rem;
       }
     </style>
 


### PR DESCRIPTION
`.iron-container { ... }` and `.iron-container::content iron-grid { ... }` had values and unit with a space between them causing them not to render on the front end.

Removed the spaces so they render.
