### PR TITLE
incorrect link import broke all subsequent imports with polymer 2

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -3,10 +3,13 @@
 
     <head>
         <title>iron-grid demo</title>
-        <script src="../../webcomponentsjs/webcomponents-loader.js"></script>
-        <link rel="import" href="../iron-grid-tester.html">
+        <base href="/components/iron-grid/">
+        <script src="../webcomponentsjs/webcomponents-lite.js"></script>
+
+        <link rel="import" href="iron-grid-tester.html">
         <link href='https://fonts.googleapis.com/css?family=Roboto' rel='stylesheet' type='text/css'>
-        <link rel="stylesheet" href="colors.css" type="text/css">
+        <link rel="stylesheet" href="demo/colors.css" type="text/css">
+
         <style>
 			html, body {
 				font-family: "Roboto", sans-serif;

--- a/iron-grid-tester.html
+++ b/iron-grid-tester.html
@@ -1,4 +1,4 @@
-<link rel="import" href="../../bower_components/polymer/polymer.html">
+<link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="iron-grid.html">
 
 <dom-module id="iron-grid-tester">

--- a/iron-grid.html
+++ b/iron-grid.html
@@ -1,7 +1,7 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-media-query/iron-media-query.html">
 <link rel="import" href="../iron-resizable-behavior/iron-resizable-behavior.html">
-<link rel="import" href="../../bower_components/polymer/lib/utils/flattened-nodes-observer.html">
+<link rel="import" href="../polymer/lib/utils/flattened-nodes-observer.html">
 
 <!--
 # Iron Container


### PR DESCRIPTION
After switching from polymer 1 to 2 lib, iron grid was not working anymore. Console said that Polymer was not loaded which was wrong. I found a similar issue with paper-input: https://github.com/PolymerElements/paper-input/issues/561
After changing the import URLs, iron-grid works again with polymer 2.
Also applied corresponding changes to the demo/page. Demo page worked well using the polymer serve command. 